### PR TITLE
RDKDEV-1002 : Fix for RDKShell Events Not Getting Triggered in Rdkservices

### DIFF
--- a/RDKShell/RDKShell.cpp
+++ b/RDKShell/RDKShell.cpp
@@ -1058,7 +1058,7 @@ namespace WPEFramework {
                            sem_wait(&request->mSemaphore);
                        }
                        gRdkShellMutex.lock();
-                       RdkShell::CompositorController::addListener(clientidentifier, mShell.mEventListener);
+		       RdkShell::CompositorController::addListener(service->Callsign(), mShell.mEventListener);
                        gRdkShellMutex.unlock();
                        gPluginDataMutex.lock();
                        std::string className = service->ClassName();


### PR DESCRIPTION
Reason for change: Added fix for RDKShell events not coming in log file

Test Procedure: Build and verify

Risks: Low

Signed-off-by: kumari_priyanka [kumari_priyanka@comcast.com](mailto:kumari_priyanka@comcast.com) 